### PR TITLE
fix(auth): add proper use of link account method

### DIFF
--- a/app/src/main/java/com/example/makeitso/screens/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/makeitso/screens/login/LoginViewModel.kt
@@ -66,17 +66,8 @@ class LoginViewModel @Inject constructor(
             val oldUserId = accountService.getUserId()
             accountService.authenticate(email, password) { error ->
                 if (error == null) {
-                    linkWithEmail()
                     updateUserId(oldUserId, openAndPopUp)
                 } else onError(error)
-            }
-        }
-    }
-
-    private fun linkWithEmail() {
-        viewModelScope.launch(showErrorExceptionHandler) {
-            accountService.linkAccount(email, password) { error ->
-                if (error != null) logService.logNonFatalCrash(error)
             }
         }
     }

--- a/app/src/main/java/com/example/makeitso/screens/sign_up/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/makeitso/screens/sign_up/SignUpViewModel.kt
@@ -80,21 +80,12 @@ class SignUpViewModel @Inject constructor(
             val createAccountTrace = Firebase.performance.newTrace(CREATE_ACCOUNT_TRACE)
             createAccountTrace.start()
 
-            accountService.createAccount(email, password) { error ->
+            accountService.linkAccount(email, password) { error ->
                 createAccountTrace.stop()
 
                 if (error == null) {
-                    linkWithEmail()
                     updateUserId(oldUserId, openAndPopUp)
                 } else onError(error)
-            }
-        }
-    }
-
-    private fun linkWithEmail() {
-        viewModelScope.launch(showErrorExceptionHandler) {
-            accountService.linkAccount(email, password) { error ->
-                if (error != null) logService.logNonFatalCrash(error)
             }
         }
     }


### PR DESCRIPTION
Hey @marinacoelho!

First, thanks for putting together your series of articles about getting started with Firebase and Compose. It was the perfect series I found to get started on a side project I'm working on.

I found a potential bug when implementing the firebase authentication. When creating an account I was getting an error stating the account was already linked to the given provider. This was happening because we were creating the account and then trying to link it to an existing (anonymous) account. But after creating the account we lost the anonymous account credentials and `Firebase.auth.currentUser` was pointing to the new authentication provider (email in this case).

[The fix](https://github.com/FirebaseExtended/make-it-so-android/compare/main...JuanAlejandro:make-it-so-android:fix/add-proper-use-of-link-account?expand=1#diff-a6c5480a0c8b137eecb9c0208025e081d07e038ab51541d4b0b0b94ad7b2c8b4R83) was to not create the account and instead "promote" it to the email provider account.

Something similar happens when the user signs in. Since the account is already created, Firebase cannot link an anonymous account with an existing one, and you cannot "promote" an already promoted account. The best we can do is to copy the data the anonymous account had, over to the logged-in account. I removed the `linkWithEmail` step because it will fail. Another thing that we can add to it is to delete the anonymous account after signing in to avoid cluttering the user database with anonymous accounts (altho we can activate the auto-cleanup to remove the anonymous account 30-days old.

If you think this is correct, it'll be great if the piece of Part 2 of your series clarifies this.

`Upon returning from a successful login or account creation, we proceed to the next step, which is to get the credentials the user used to sign in to the second authentication provider, and link them to the anonymous account`

I hope this helps and makes sense.

Thank you again 🙏 
