### PR TITLE
Remove unnecessary userId update

### DIFF
--- a/app/src/main/java/com/example/makeitso/MakeItSoAppState.kt
+++ b/app/src/main/java/com/example/makeitso/MakeItSoAppState.kt
@@ -23,7 +23,6 @@ import androidx.navigation.NavHostController
 import com.example.makeitso.common.snackbar.SnackbarManager
 import com.example.makeitso.common.snackbar.SnackbarMessage.Companion.toMessage
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/example/makeitso/model/service/AccountService.kt
+++ b/app/src/main/java/com/example/makeitso/model/service/AccountService.kt
@@ -21,7 +21,6 @@ interface AccountService {
     fun isAnonymousUser(): Boolean
     fun getUserId(): String
     fun authenticate(email: String, password: String, onResult: (Throwable?) -> Unit)
-    fun createAccount(email: String, password: String, onResult: (Throwable?) -> Unit)
     fun sendRecoveryEmail(email: String, onResult: (Throwable?) -> Unit)
     fun createAnonymousAccount(onResult: (Throwable?) -> Unit)
     fun linkAccount(email: String, password: String, onResult: (Throwable?) -> Unit)

--- a/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
+++ b/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
@@ -31,5 +31,4 @@ interface StorageService {
     fun updateTask(task: Task, onResult: (Throwable?) -> Unit)
     fun deleteTask(taskId: String, onResult: (Throwable?) -> Unit)
     fun deleteAllForUser(userId: String, onResult: (Throwable?) -> Unit)
-    fun updateUserId(oldUserId: String, newUserId: String, onResult: (Throwable?) -> Unit)
 }

--- a/app/src/main/java/com/example/makeitso/model/service/impl/AccountServiceImpl.kt
+++ b/app/src/main/java/com/example/makeitso/model/service/impl/AccountServiceImpl.kt
@@ -40,11 +40,6 @@ class AccountServiceImpl @Inject constructor() : AccountService {
             .addOnCompleteListener { onResult(it.exception) }
     }
 
-    override fun createAccount(email: String, password: String, onResult: (Throwable?) -> Unit) {
-        Firebase.auth.createUserWithEmailAndPassword(email, password)
-            .addOnCompleteListener { onResult(it.exception) }
-    }
-
     override fun sendRecoveryEmail(email: String, onResult: (Throwable?) -> Unit) {
         Firebase.auth.sendPasswordResetEmail(email)
             .addOnCompleteListener { onResult(it.exception) }

--- a/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
+++ b/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
@@ -104,22 +104,6 @@ class StorageServiceImpl @Inject constructor() : StorageService {
             }
     }
 
-    override fun updateUserId(
-        oldUserId: String,
-        newUserId: String,
-        onResult: (Throwable?) -> Unit
-    ) {
-        Firebase.firestore
-            .collection(TASK_COLLECTION)
-            .whereEqualTo(USER_ID, oldUserId)
-            .get()
-            .addOnFailureListener { error -> onResult(error) }
-            .addOnSuccessListener { result ->
-                for (document in result) document.reference.update(USER_ID, newUserId)
-                onResult(null)
-            }
-    }
-
     companion object {
         private const val TASK_COLLECTION = "Task"
         private const val USER_ID = "userId"

--- a/app/src/main/java/com/example/makeitso/screens/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/makeitso/screens/login/LoginViewModel.kt
@@ -25,7 +25,6 @@ import com.example.makeitso.common.ext.isValidEmail
 import com.example.makeitso.common.snackbar.SnackbarManager
 import com.example.makeitso.model.service.AccountService
 import com.example.makeitso.model.service.LogService
-import com.example.makeitso.model.service.StorageService
 import com.example.makeitso.screens.MakeItSoViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -34,8 +33,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val accountService: AccountService,
-    private val storageService: StorageService,
-    private val logService: LogService
+    logService: LogService
 ) : MakeItSoViewModel(logService) {
     var uiState = mutableStateOf(LoginUiState())
         private set
@@ -63,22 +61,10 @@ class LoginViewModel @Inject constructor(
         }
 
         viewModelScope.launch(showErrorExceptionHandler) {
-            val oldUserId = accountService.getUserId()
             accountService.authenticate(email, password) { error ->
                 if (error == null) {
-                    updateUserId(oldUserId, openAndPopUp)
+                    openAndPopUp(SETTINGS_SCREEN, LOGIN_SCREEN)
                 } else onError(error)
-            }
-        }
-    }
-
-    private fun updateUserId(oldUserId: String, openAndPopUp: (String, String) -> Unit) {
-        viewModelScope.launch(showErrorExceptionHandler) {
-            val newUserId = accountService.getUserId()
-
-            storageService.updateUserId(oldUserId, newUserId) { error ->
-                if (error != null) logService.logNonFatalCrash(error)
-                else openAndPopUp(SETTINGS_SCREEN, LOGIN_SCREEN)
             }
         }
     }

--- a/app/src/main/java/com/example/makeitso/screens/sign_up/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/makeitso/screens/sign_up/SignUpViewModel.kt
@@ -27,7 +27,6 @@ import com.example.makeitso.common.ext.passwordMatches
 import com.example.makeitso.common.snackbar.SnackbarManager
 import com.example.makeitso.model.service.AccountService
 import com.example.makeitso.model.service.LogService
-import com.example.makeitso.model.service.StorageService
 import com.example.makeitso.screens.MakeItSoViewModel
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.perf.ktx.performance
@@ -38,8 +37,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SignUpViewModel @Inject constructor(
     private val accountService: AccountService,
-    private val storageService: StorageService,
-    private val logService: LogService
+    logService: LogService
 ) : MakeItSoViewModel(logService) {
     var uiState = mutableStateOf(SignUpUiState())
         private set
@@ -76,7 +74,6 @@ class SignUpViewModel @Inject constructor(
         }
 
         viewModelScope.launch(showErrorExceptionHandler) {
-            val oldUserId = accountService.getUserId()
             val createAccountTrace = Firebase.performance.newTrace(CREATE_ACCOUNT_TRACE)
             createAccountTrace.start()
 
@@ -84,19 +81,8 @@ class SignUpViewModel @Inject constructor(
                 createAccountTrace.stop()
 
                 if (error == null) {
-                    updateUserId(oldUserId, openAndPopUp)
+                    openAndPopUp(SETTINGS_SCREEN, SIGN_UP_SCREEN)
                 } else onError(error)
-            }
-        }
-    }
-
-    private fun updateUserId(oldUserId: String, openAndPopUp: (String, String) -> Unit) {
-        viewModelScope.launch(showErrorExceptionHandler) {
-            val newUserId = accountService.getUserId()
-
-            storageService.updateUserId(oldUserId, newUserId) { error ->
-                if (error != null) logService.logNonFatalCrash(error)
-                else openAndPopUp(SETTINGS_SCREEN, SIGN_UP_SCREEN)
             }
         }
     }

--- a/app/src/main/java/com/example/makeitso/screens/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/example/makeitso/screens/splash/SplashViewModel.kt
@@ -16,12 +16,10 @@ limitations under the License.
 
 package com.example.makeitso.screens.splash
 
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.viewModelScope
 import com.example.makeitso.SPLASH_SCREEN
 import com.example.makeitso.TASKS_SCREEN
-import com.example.makeitso.model.Task
 import com.example.makeitso.model.service.AccountService
 import com.example.makeitso.model.service.ConfigurationService
 import com.example.makeitso.model.service.LogService


### PR DESCRIPTION
Now that the `linkAccount()` method is being used correctly, we don't need to update the `userId` anymore, because it remains the same.