### PR TITLE
Clear tasks when removing listener storage listener

### DIFF
--- a/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
@@ -52,6 +52,7 @@ class TasksViewModel @Inject constructor(
     }
 
     fun removeListener() {
+        tasks.clear()
         viewModelScope.launch(showErrorExceptionHandler) { storageService.removeListener() }
     }
 


### PR DESCRIPTION
There is a subtle bug making tasks map store inconsistent data

Reproduce
- Make sure you are not logged in
- Create a task
- Login to an existing account
- Going back to the tasks page, the task created on step two will be there (ViewModel was persisted). Now you won't be to edit it because it is no longer linked to your account. 

Why: Logic to update userId during the login process was removed #18 

Fix: Clear tasks when removing the storage listener on the tasks ViewModel



