### PR TITLE
Removed deleting tasks for user

### DIFF
--- a/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
+++ b/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
@@ -27,5 +27,4 @@ interface StorageService {
   suspend fun save(task: Task): String
   suspend fun update(task: Task)
   suspend fun delete(taskId: String)
-  suspend fun deleteAllForUser(userId: String)
 }

--- a/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
+++ b/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
@@ -61,13 +61,6 @@ constructor(private val firestore: FirebaseFirestore, private val auth: AccountS
     currentCollection(auth.currentUserId).document(taskId).delete().await()
   }
 
-  // TODO: It's not recommended to delete on the client:
-  // https://firebase.google.com/docs/firestore/manage-data/delete-data#kotlin+ktx_2
-  override suspend fun deleteAllForUser(userId: String) {
-    val matchingTasks = currentCollection(userId).get().await()
-    matchingTasks.map { it.reference.delete().asDeferred() }.awaitAll()
-  }
-
   private fun currentCollection(uid: String): CollectionReference =
     firestore.collection(USER_COLLECTION).document(uid).collection(TASK_COLLECTION)
 

--- a/app/src/main/java/com/example/makeitso/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/makeitso/screens/settings/SettingsViewModel.kt
@@ -48,7 +48,6 @@ class SettingsViewModel @Inject constructor(
 
   fun onDeleteMyAccountClick(restartApp: (String) -> Unit) {
     launchCatching {
-      storageService.deleteAllForUser(accountService.currentUserId)
       accountService.deleteAccount()
       restartApp(SPLASH_SCREEN)
     }


### PR DESCRIPTION
Removed code that deleted all To-do items for an user when the user was deleted from the user base. Make it So app will use an extension that handles it from now on.