### PR TITLE
Add FCM to Make it So

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 .settings
 .classpath
 google-services.json
+.idea/
+.idea/*
+local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
     implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4'
+    implementation 'com.google.accompanist:accompanist-permissions:0.30.1'
     implementation 'com.google.dagger:hilt-android:2.44'
     kapt 'com.google.dagger:hilt-compiler:2.44'
 
@@ -91,6 +92,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-firestore-ktx'
     implementation 'com.google.firebase:firebase-perf-ktx'
     implementation 'com.google.firebase:firebase-config-ktx'
+    implementation 'com.google.firebase:firebase-messaging-ktx'
 
     //Test
     testImplementation 'junit:junit:4.+'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".MakeItSoMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@mipmap/ic_launcher" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/dark_orange" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/default_notification_channel_id" />
         <meta-data
             android:name="firebase_performance_logcat_enabled"
             android:value="true" />

--- a/app/src/main/java/com/example/makeitso/MakeItSoApp.kt
+++ b/app/src/main/java/com/example/makeitso/MakeItSoApp.kt
@@ -16,7 +16,10 @@ limitations under the License.
 
 package com.example.makeitso
 
+import android.Manifest
 import android.content.res.Resources
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
@@ -33,6 +36,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.example.makeitso.common.composable.PermissionDialog
+import com.example.makeitso.common.composable.RationaleDialog
 import com.example.makeitso.common.snackbar.SnackbarManager
 import com.example.makeitso.screens.edit_task.EditTaskScreen
 import com.example.makeitso.screens.login.LoginScreen
@@ -41,12 +46,20 @@ import com.example.makeitso.screens.sign_up.SignUpScreen
 import com.example.makeitso.screens.splash.SplashScreen
 import com.example.makeitso.screens.tasks.TasksScreen
 import com.example.makeitso.theme.MakeItSoTheme
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+import com.google.accompanist.permissions.shouldShowRationale
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
 @ExperimentalMaterialApi
 fun MakeItSoApp() {
   MakeItSoTheme {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      RequestNotificationPermissionDialog()
+    }
+
     Surface(color = MaterialTheme.colors.background) {
       val appState = rememberAppState()
 
@@ -71,6 +84,18 @@ fun MakeItSoApp() {
         }
       }
     }
+  }
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun RequestNotificationPermissionDialog() {
+  val permissionState = rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS)
+
+  if (!permissionState.status.isGranted) {
+    if (permissionState.status.shouldShowRationale) RationaleDialog()
+    else PermissionDialog { permissionState.launchPermissionRequest() }
   }
 }
 

--- a/app/src/main/java/com/example/makeitso/MakeItSoMessagingService.kt
+++ b/app/src/main/java/com/example/makeitso/MakeItSoMessagingService.kt
@@ -1,18 +1,68 @@
 package com.example.makeitso
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.NotificationManager.IMPORTANCE_DEFAULT
+import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
+import android.os.Build
 import android.util.Log
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import kotlin.random.Random
 
 class MakeItSoMessagingService : FirebaseMessagingService() {
-    /**
-     * Called if the FCM registration token is updated. This may occur if the security of
-     * the previous token had been compromised. This is called when the FCM registration
-     * token is initially generated so this is where you would retrieve the token.
-     */
+
+    private val random = Random
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        remoteMessage.notification?.let { message ->
+            sendNotification(message)
+        }
+    }
+
+    @OptIn(ExperimentalMaterialApi::class)
+    private fun sendNotification(message: RemoteMessage.Notification) {
+        // If you want the notifications to appear when your app is in foreground
+
+        val intent = Intent(this, MakeItSoActivity::class.java).apply {
+            addFlags(FLAG_ACTIVITY_CLEAR_TOP)
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, intent, FLAG_IMMUTABLE
+        )
+
+        val channelId = this.getString(R.string.default_notification_channel_id)
+
+        val notificationBuilder = NotificationCompat.Builder(this, channelId)
+            .setContentTitle(message.title)
+            .setContentText(message.body)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(channelId, CHANNEL_NAME, IMPORTANCE_DEFAULT)
+            manager.createNotificationChannel(channel)
+        }
+
+        manager.notify(random.nextInt(), notificationBuilder.build())
+    }
+
     override fun onNewToken(token: String) {
         // If you want to send messages to this application instance or
         // manage this apps subscriptions on the server side, send the
         // FCM registration token to your app server.
         Log.d("FCM","New token: $token")
+    }
+
+    companion object {
+        const val CHANNEL_NAME = "FCM notification channel"
     }
 }

--- a/app/src/main/java/com/example/makeitso/MakeItSoMessagingService.kt
+++ b/app/src/main/java/com/example/makeitso/MakeItSoMessagingService.kt
@@ -1,0 +1,18 @@
+package com.example.makeitso
+
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessagingService
+
+class MakeItSoMessagingService : FirebaseMessagingService() {
+    /**
+     * Called if the FCM registration token is updated. This may occur if the security of
+     * the previous token had been compromised. This is called when the FCM registration
+     * token is initially generated so this is where you would retrieve the token.
+     */
+    override fun onNewToken(token: String) {
+        // If you want to send messages to this application instance or
+        // manage this apps subscriptions on the server side, send the
+        // FCM registration token to your app server.
+        Log.d("FCM","New token: $token")
+    }
+}

--- a/app/src/main/java/com/example/makeitso/common/composable/PermissionDialogComposable.kt
+++ b/app/src/main/java/com/example/makeitso/common/composable/PermissionDialogComposable.kt
@@ -1,13 +1,20 @@
 package com.example.makeitso.common.composable
 
 import androidx.compose.material.AlertDialog
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import com.example.makeitso.common.ext.alertDialog
+import com.example.makeitso.common.ext.textButton
+import com.example.makeitso.theme.BrightOrange
 import com.example.makeitso.R.string as AppText
 
 @Composable
@@ -16,15 +23,23 @@ fun PermissionDialog(onRequestPermission: () -> Unit) {
 
     if (showWarningDialog) {
         AlertDialog(
+            modifier = Modifier.alertDialog(),
             title = { Text(stringResource(id = AppText.notification_permission_title)) },
             text = { Text(stringResource(id = AppText.notification_permission_description)) },
             confirmButton = {
-                DialogConfirmButton(AppText.request_notification_permission) {
-                    onRequestPermission()
-                    showWarningDialog = false
-                }
+                TextButton(
+                    onClick = {
+                        onRequestPermission()
+                        showWarningDialog = false
+                    },
+                    modifier = Modifier.textButton(),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = BrightOrange,
+                        contentColor = Color.White
+                    )
+                ) { Text(text = stringResource(AppText.request_notification_permission)) }
             },
-            onDismissRequest = { showWarningDialog = true }
+            onDismissRequest = { }
         )
     }
 }
@@ -35,12 +50,18 @@ fun RationaleDialog() {
 
     if (showWarningDialog) {
         AlertDialog(
+            modifier = Modifier.alertDialog(),
             title = { Text(stringResource(id = AppText.notification_permission_title)) },
             text = { Text(stringResource(id = AppText.notification_permission_settings)) },
             confirmButton = {
-                DialogConfirmButton(AppText.ok) {
-                    showWarningDialog = false
-                }
+                TextButton(
+                    onClick = { showWarningDialog = false },
+                    modifier = Modifier.textButton(),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = BrightOrange,
+                        contentColor = Color.White
+                    )
+                ) { Text(text = stringResource(AppText.ok)) }
             },
             onDismissRequest = { showWarningDialog = false }
         )

--- a/app/src/main/java/com/example/makeitso/common/composable/PermissionDialogComposable.kt
+++ b/app/src/main/java/com/example/makeitso/common/composable/PermissionDialogComposable.kt
@@ -1,0 +1,48 @@
+package com.example.makeitso.common.composable
+
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import com.example.makeitso.R.string as AppText
+
+@Composable
+fun PermissionDialog(onRequestPermission: () -> Unit) {
+    var showWarningDialog by remember { mutableStateOf(true) }
+
+    if (showWarningDialog) {
+        AlertDialog(
+            title = { Text(stringResource(id = AppText.notification_permission_title)) },
+            text = { Text(stringResource(id = AppText.notification_permission_description)) },
+            confirmButton = {
+                DialogConfirmButton(AppText.request_notification_permission) {
+                    onRequestPermission()
+                    showWarningDialog = false
+                }
+            },
+            onDismissRequest = { showWarningDialog = true }
+        )
+    }
+}
+
+@Composable
+fun RationaleDialog() {
+    var showWarningDialog by remember { mutableStateOf(true) }
+
+    if (showWarningDialog) {
+        AlertDialog(
+            title = { Text(stringResource(id = AppText.notification_permission_title)) },
+            text = { Text(stringResource(id = AppText.notification_permission_settings)) },
+            confirmButton = {
+                DialogConfirmButton(AppText.ok) {
+                    showWarningDialog = false
+                }
+            },
+            onDismissRequest = { showWarningDialog = false }
+        )
+    }
+}

--- a/app/src/main/java/com/example/makeitso/common/ext/ModifierExt.kt
+++ b/app/src/main/java/com/example/makeitso/common/ext/ModifierExt.kt
@@ -37,6 +37,10 @@ fun Modifier.contextMenu(): Modifier {
   return this.wrapContentWidth()
 }
 
+fun Modifier.alertDialog(): Modifier {
+  return this.wrapContentWidth().wrapContentHeight()
+}
+
 fun Modifier.dropdownSelector(): Modifier {
   return this.fillMaxWidth()
 }

--- a/app/src/main/java/com/example/makeitso/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/makeitso/screens/splash/SplashScreen.kt
@@ -16,9 +16,6 @@ limitations under the License.
 
 package com.example.makeitso.screens.splash
 
-import android.Manifest
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -34,13 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.makeitso.R.string as AppText
 import com.example.makeitso.common.composable.BasicButton
-import com.example.makeitso.common.composable.PermissionDialog
-import com.example.makeitso.common.composable.RationaleDialog
 import com.example.makeitso.common.ext.basicButton
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.isGranted
-import com.google.accompanist.permissions.rememberPermissionState
-import com.google.accompanist.permissions.shouldShowRationale
 import kotlinx.coroutines.delay
 
 private const val SPLASH_TIMEOUT = 1000L
@@ -51,10 +42,6 @@ fun SplashScreen(
   modifier: Modifier = Modifier,
   viewModel: SplashViewModel = hiltViewModel()
 ) {
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-    RequestNotificationPermissionDialog()
-  }
-
   Column(
     modifier =
       modifier
@@ -77,18 +64,5 @@ fun SplashScreen(
   LaunchedEffect(true) {
     delay(SPLASH_TIMEOUT)
     viewModel.onAppStart(openAndPopUp)
-  }
-}
-
-//TODO: Find a better place to request for permissions
-@RequiresApi(Build.VERSION_CODES.TIRAMISU)
-@OptIn(ExperimentalPermissionsApi::class)
-@Composable
-fun RequestNotificationPermissionDialog() {
-  val permissionState = rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS)
-
-  if (!permissionState.status.isGranted) {
-    if (permissionState.status.shouldShowRationale) RationaleDialog()
-    else PermissionDialog { permissionState.launchPermissionRequest() }
   }
 }

--- a/app/src/main/java/com/example/makeitso/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/makeitso/screens/splash/SplashScreen.kt
@@ -16,6 +16,9 @@ limitations under the License.
 
 package com.example.makeitso.screens.splash
 
+import android.Manifest
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -31,7 +34,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.makeitso.R.string as AppText
 import com.example.makeitso.common.composable.BasicButton
+import com.example.makeitso.common.composable.PermissionDialog
+import com.example.makeitso.common.composable.RationaleDialog
 import com.example.makeitso.common.ext.basicButton
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+import com.google.accompanist.permissions.shouldShowRationale
 import kotlinx.coroutines.delay
 
 private const val SPLASH_TIMEOUT = 1000L
@@ -42,6 +51,10 @@ fun SplashScreen(
   modifier: Modifier = Modifier,
   viewModel: SplashViewModel = hiltViewModel()
 ) {
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    RequestNotificationPermissionDialog()
+  }
+
   Column(
     modifier =
       modifier
@@ -64,5 +77,18 @@ fun SplashScreen(
   LaunchedEffect(true) {
     delay(SPLASH_TIMEOUT)
     viewModel.onAppStart(openAndPopUp)
+  }
+}
+
+//TODO: Find a better place to request for permissions
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun RequestNotificationPermissionDialog() {
+  val permissionState = rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS)
+
+  if (!permissionState.status.isGranted) {
+    if (permissionState.status.shouldShowRationale) RationaleDialog()
+    else PermissionDialog { permissionState.launchPermissionRequest() }
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="email_error">Please insert a valid email.</string>
     <string name="cancel">Cancel</string>
     <string name="try_again">Try again</string>
+    <string name="ok">OK</string>
 
     <!-- LoginScreen -->
     <string name="sign_in">Sign in</string>
@@ -44,4 +45,11 @@
     <string name="sign_out_description">You will have to sign in again to see your tasks.</string>
     <string name="delete_account_title">Delete account?</string>
     <string name="delete_account_description">You will lose all your tasks and your account will be deleted. This action is irreversible.</string>
+
+    <!-- FCM -->
+    <string name="default_notification_channel_id" translatable="false">fcm_default_channel</string>
+    <string name="request_notification_permission">Request permission</string>
+    <string name="notification_permission_title">Notification permission</string>
+    <string name="notification_permission_description">The notification permission is important for this app. Please grant the permission.</string>
+    <string name="notification_permission_settings">The notification permission is important for this app. Please navigate to your device settings and enable notifications for Make it So.</string>
 </resources>


### PR DESCRIPTION
This PR adds Firebase Cloud Messaging to Make it So and shows a dialog to the user as soon as the app is launched explaining that this permission is important for the app. When the user clicks on the "Request permission" button of this dialog, we call the OS dialog for enabling Push Notifications.