### PR TITLE
chore: use stable API level 34

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order for this app to work, you will need to create a [Firebase project](http
 * [Create a Cloud Firestore database](https://firebase.google.com/docs/firestore/quickstart#create) in your Firebase project
 * [Enable Anonymous Authentication](https://firebase.google.com/docs/auth/android/anonymous-auth#before-you-begin) in your Firebase project
 * [Enable Email/Password Authentication](https://firebase.google.com/docs/auth/android/password-auth#before_you_begin) in your Firebase project
-* Run the app using Android Studio Flamingo+ on a device/emulator with API "UpsideDownCake" or above
+* Run the app using Android Studio Flamingo+ on a device/emulator with API level 21 or above
 
 ## Contact
 

--- a/final/app/build.gradle.kts
+++ b/final/app/build.gradle.kts
@@ -10,17 +10,15 @@ plugins {
 }
 
 android {
-    compileSdk = 33
-    compileSdkPreview = "UpsideDownCake"
+    compileSdk = 34
     namespace = "com.example.makeitso"
 
     defaultConfig {
         applicationId = "com.example.makeitso"
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
-        targetSdkPreview = "UpsideDownCake"
 
         testInstrumentationRunner = "com.example.makeitso.MakeItSoTestRunner"
         vectorDrawables.useSupportLibrary = true
@@ -73,8 +71,8 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended:$composeVersion")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
-    implementation("androidx.activity:activity-compose:1.8.0-alpha03")
-    implementation("androidx.navigation:navigation-compose:2.6.0-alpha09")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.navigation:navigation-compose:2.6.0")
     implementation("androidx.hilt:hilt-navigation-compose:1.0.0")
     implementation("androidx.preference:preference-ktx:1.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")

--- a/start/app/build.gradle.kts
+++ b/start/app/build.gradle.kts
@@ -10,17 +10,15 @@ plugins {
 }
 
 android {
-    compileSdk = 33
-    compileSdkPreview = "UpsideDownCake"
+    compileSdk = 34
     namespace = "com.example.makeitso"
 
     defaultConfig {
         applicationId = "com.example.makeitso"
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
-        targetSdkPreview = "UpsideDownCake"
 
         testInstrumentationRunner = "com.example.makeitso.MakeItSoTestRunner"
         vectorDrawables.useSupportLibrary = true
@@ -73,8 +71,8 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended:$composeVersion")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
-    implementation("androidx.activity:activity-compose:1.8.0-alpha03")
-    implementation("androidx.navigation:navigation-compose:2.6.0-alpha09")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.navigation:navigation-compose:2.6.0")
     implementation("androidx.hilt:hilt-navigation-compose:1.0.0")
     implementation("androidx.preference:preference-ktx:1.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")


### PR DESCRIPTION
This should allow the app to run in emulator devices with older Android versions. I had to downgrade `activity-compose` and `navigation-compose` which were using alpha versions.