### PR TITLE
Add statistics screen

### DIFF
--- a/final/app/build.gradle.kts
+++ b/final/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.makeitso"
-        minSdk = 21
+        minSdk = 26
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/final/app/build.gradle.kts
+++ b/final/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.makeitso"
-        minSdk = 26
+        minSdk = 21
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/final/app/src/main/java/com/example/makeitso/MakeItSoApp.kt
+++ b/final/app/src/main/java/com/example/makeitso/MakeItSoApp.kt
@@ -44,6 +44,7 @@ import com.example.makeitso.screens.login.LoginScreen
 import com.example.makeitso.screens.settings.SettingsScreen
 import com.example.makeitso.screens.sign_up.SignUpScreen
 import com.example.makeitso.screens.splash.SplashScreen
+import com.example.makeitso.screens.stats.StatsScreen
 import com.example.makeitso.screens.tasks.TasksScreen
 import com.example.makeitso.theme.MakeItSoTheme
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -129,6 +130,10 @@ fun NavGraphBuilder.makeItSoGraph(appState: MakeItSoAppState) {
       restartApp = { route -> appState.clearAndNavigate(route) },
       openScreen = { route -> appState.navigate(route) }
     )
+  }
+
+  composable(STATS_SCREEN) {
+    StatsScreen()
   }
 
   composable(LOGIN_SCREEN) {

--- a/final/app/src/main/java/com/example/makeitso/common/composable/ToolbarComposable.kt
+++ b/final/app/src/main/java/com/example/makeitso/common/composable/ToolbarComposable.kt
@@ -20,8 +20,12 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -34,18 +38,29 @@ fun BasicToolbar(@StringRes title: Int) {
 
 @Composable
 fun ActionToolbar(
-  @StringRes title: Int,
-  @DrawableRes endActionIcon: Int,
   modifier: Modifier,
-  endAction: () -> Unit
+  @StringRes title: Int,
+  @DrawableRes primaryActionIcon: Int,
+  primaryAction: () -> Unit,
+  @DrawableRes secondaryActionIcon: Int? = null,
+  secondaryAction: (() -> Unit)? = null
 ) {
   TopAppBar(
     title = { Text(stringResource(title)) },
     backgroundColor = toolbarColor(),
     actions = {
       Box(modifier) {
-        IconButton(onClick = endAction) {
-          Icon(painter = painterResource(endActionIcon), contentDescription = "Action")
+        Row(
+          modifier = Modifier.wrapContentSize(),
+        ) {
+          IconButton(onClick = primaryAction) {
+            Icon(painter = painterResource(primaryActionIcon), contentDescription = "Primary Action")
+          }
+          if (secondaryAction != null && secondaryActionIcon != null) {
+            IconButton(onClick = secondaryAction) {
+              Icon(painter = painterResource(secondaryActionIcon), contentDescription = "Secondary Action")
+            }
+          }
         }
       }
     }

--- a/final/app/src/main/java/com/example/makeitso/model/Task.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/Task.kt
@@ -17,10 +17,12 @@ limitations under the License.
 package com.example.makeitso.model
 
 import com.google.firebase.firestore.DocumentId
+import com.google.firebase.firestore.ServerTimestamp
+import java.util.Date
 
 data class Task(
   @DocumentId val id: String = "",
-  val creationInstant: String = "",
+  @ServerTimestamp val creationInstant: Date = Date(),
   val title: String = "",
   val priority: String = "",
   val dueDate: String = "",

--- a/final/app/src/main/java/com/example/makeitso/model/Task.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/Task.kt
@@ -22,7 +22,7 @@ import java.util.Date
 
 data class Task(
   @DocumentId val id: String = "",
-  @ServerTimestamp val creationInstant: Date = Date(),
+  @ServerTimestamp val createdAt: Date = Date(),
   val title: String = "",
   val priority: String = "",
   val dueDate: String = "",
@@ -31,6 +31,6 @@ data class Task(
   val url: String = "",
   val flag: Boolean = false,
   val completed: Boolean = false,
-  val completionTime: Long? = null,
+  val averageCompletionTime: Long? = null,
   val userId: String = ""
 )

--- a/final/app/src/main/java/com/example/makeitso/model/Task.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/Task.kt
@@ -29,6 +29,6 @@ data class Task(
   val url: String = "",
   val flag: Boolean = false,
   val completed: Boolean = false,
-  val completionTime: Int? = null,
+  val completionTime: Long? = null,
   val userId: String = ""
 )

--- a/final/app/src/main/java/com/example/makeitso/model/Task.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/Task.kt
@@ -31,6 +31,5 @@ data class Task(
   val url: String = "",
   val flag: Boolean = false,
   val completed: Boolean = false,
-  val averageCompletionTime: Long? = null,
   val userId: String = ""
 )

--- a/final/app/src/main/java/com/example/makeitso/model/Task.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/Task.kt
@@ -20,6 +20,7 @@ import com.google.firebase.firestore.DocumentId
 
 data class Task(
   @DocumentId val id: String = "",
+  val creationInstant: String = "",
   val title: String = "",
   val priority: String = "",
   val dueDate: String = "",
@@ -28,5 +29,6 @@ data class Task(
   val url: String = "",
   val flag: Boolean = false,
   val completed: Boolean = false,
+  val completionTime: Int? = null,
   val userId: String = ""
 )

--- a/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
@@ -25,4 +25,9 @@ interface StorageService {
   suspend fun save(task: Task): String
   suspend fun update(task: Task)
   suspend fun delete(taskId: String)
+  suspend fun getCompletedTasksCount(): Int
+  suspend fun getImportantCompletedTasksCount(): Int
+  suspend fun getAverageCompletionTime(): Int
+  suspend fun getMediumHighTasksToCompleteCount(): Int
+  suspend fun getOverdueTasksCount(): Int
 }

--- a/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
@@ -25,9 +25,8 @@ interface StorageService {
   suspend fun save(task: Task): String
   suspend fun update(task: Task)
   suspend fun delete(taskId: String)
-  suspend fun getCompletedTasksCount(): Int
+  suspend fun getCompletedTasksCount(): Long
   suspend fun getImportantCompletedTasksCount(): Int
-  suspend fun getAverageCompletionTime(): Int
-  suspend fun getMediumHighTasksToCompleteCount(): Int
-  suspend fun getOverdueTasksCount(): Int
+  suspend fun getAverageCompletionTime(): Long
+  suspend fun getMediumHighTasksToCompleteCount(): Long
 }

--- a/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
@@ -26,7 +26,7 @@ interface StorageService {
   suspend fun update(task: Task)
   suspend fun delete(taskId: String)
   suspend fun getCompletedTasksCount(): Long
-  suspend fun getImportantCompletedTasksCount(): Int
+  suspend fun getImportantCompletedTasksCount(): Long
   suspend fun getAverageCompletionTime(): Long
   suspend fun getMediumHighTasksToCompleteCount(): Long
 }

--- a/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
@@ -25,7 +25,7 @@ interface StorageService {
   suspend fun save(task: Task): String
   suspend fun update(task: Task)
   suspend fun delete(taskId: String)
-  suspend fun getCompletedTasksCount(): Long
-  suspend fun getImportantCompletedTasksCount(): Long
-  suspend fun getMediumHighTasksToCompleteCount(): Long
+  suspend fun getCompletedTasksCount(): Int
+  suspend fun getImportantCompletedTasksCount(): Int
+  suspend fun getMediumHighTasksToCompleteCount(): Int
 }

--- a/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/StorageService.kt
@@ -27,6 +27,5 @@ interface StorageService {
   suspend fun delete(taskId: String)
   suspend fun getCompletedTasksCount(): Long
   suspend fun getImportantCompletedTasksCount(): Long
-  suspend fun getAverageCompletionTime(): Long
   suspend fun getMediumHighTasksToCompleteCount(): Long
 }

--- a/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
@@ -33,8 +33,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.tasks.await
-import java.time.Instant
-import java.time.format.DateTimeFormatter.ISO_INSTANT
 
 class StorageServiceImpl @Inject constructor(
   private val firestore: FirebaseFirestore,
@@ -56,8 +54,7 @@ class StorageServiceImpl @Inject constructor(
 
   override suspend fun save(task: Task): String =
     trace(SAVE_TASK_TRACE) {
-      val instant = ISO_INSTANT.format(Instant.now())
-      val updatedTask = task.copy(userId = auth.currentUserId, creationInstant = instant)
+     val updatedTask = task.copy(userId = auth.currentUserId)
       firestore.collection(TASK_COLLECTION).add(updatedTask).await().id
     }
 

--- a/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
@@ -105,7 +105,7 @@ class StorageServiceImpl @Inject constructor(
     private const val COMPLETED_FIELD = "completed"
     private const val PRIORITY_FIELD = "priority"
     private const val FLAG_FIELD = "flag"
-    private const val COMPLETION_TIME_FIELD = "completionTime"
+    private const val COMPLETION_TIME_FIELD = "averageCompletionTime"
     private const val TASK_COLLECTION = "tasks"
     private const val SAVE_TASK_TRACE = "saveTask"
     private const val UPDATE_TASK_TRACE = "updateTask"

--- a/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
@@ -70,12 +70,12 @@ class StorageServiceImpl @Inject constructor(
     firestore.collection(TASK_COLLECTION).document(taskId).delete().await()
   }
 
-  override suspend fun getCompletedTasksCount(): Long {
+  override suspend fun getCompletedTasksCount(): Int {
     val query = collection.whereEqualTo(COMPLETED_FIELD, true).count()
-    return query.get(AggregateSource.SERVER).await().count
+    return query.get(AggregateSource.SERVER).await().count.toInt()
   }
 
-  override suspend fun getImportantCompletedTasksCount(): Long {
+  override suspend fun getImportantCompletedTasksCount(): Int {
     val query = collection.where(
       Filter.and(
         Filter.equalTo(COMPLETED_FIELD, true),
@@ -86,15 +86,15 @@ class StorageServiceImpl @Inject constructor(
       )
     )
 
-    return query.count().get(AggregateSource.SERVER).await().count
+    return query.count().get(AggregateSource.SERVER).await().count.toInt()
   }
 
-  override suspend fun getMediumHighTasksToCompleteCount(): Long {
+  override suspend fun getMediumHighTasksToCompleteCount(): Int {
     val query = collection
       .whereEqualTo(COMPLETED_FIELD, false)
       .whereIn(PRIORITY_FIELD, listOf(Priority.Medium.name, Priority.High.name)).count()
 
-    return query.get(AggregateSource.SERVER).await().count
+    return query.get(AggregateSource.SERVER).await().count.toInt()
   }
 
   companion object {

--- a/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
@@ -28,6 +28,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.tasks.await
+import java.time.Instant
+import java.time.format.DateTimeFormatter.ISO_INSTANT
 
 class StorageServiceImpl @Inject constructor(
   private val firestore: FirebaseFirestore,
@@ -46,8 +48,9 @@ class StorageServiceImpl @Inject constructor(
 
   override suspend fun save(task: Task): String =
     trace(SAVE_TASK_TRACE) {
-      val taskWithUserId = task.copy(userId = auth.currentUserId)
-      firestore.collection(TASK_COLLECTION).add(taskWithUserId).await().id
+      val instant = ISO_INSTANT.format(Instant.now())
+      val updatedTask = task.copy(userId = auth.currentUserId, creationInstant = instant)
+      firestore.collection(TASK_COLLECTION).add(updatedTask).await().id
     }
 
   override suspend fun update(task: Task): Unit =

--- a/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
@@ -25,7 +25,6 @@ import com.google.firebase.firestore.AggregateField
 import com.google.firebase.firestore.AggregateSource
 import com.google.firebase.firestore.Filter
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.Source
 import com.google.firebase.firestore.dataObjects
 import com.google.firebase.firestore.toObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -72,7 +71,7 @@ class StorageServiceImpl @Inject constructor(
     return query.get(AggregateSource.SERVER).await().count
   }
 
-  override suspend fun getImportantCompletedTasksCount(): Int {
+  override suspend fun getImportantCompletedTasksCount(): Long {
     val query = collection.where(
       Filter.and(
         Filter.equalTo(COMPLETED_FIELD, true),
@@ -83,7 +82,7 @@ class StorageServiceImpl @Inject constructor(
       )
     )
 
-    return query.get(Source.SERVER).await().count()
+    return query.count().get(AggregateSource.SERVER).await().count
   }
 
   override suspend fun getAverageCompletionTime(): Long {

--- a/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
+++ b/final/app/src/main/java/com/example/makeitso/model/service/impl/StorageServiceImpl.kt
@@ -29,10 +29,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.tasks.await
 
-class StorageServiceImpl
-@Inject
-constructor(private val firestore: FirebaseFirestore, private val auth: AccountService) :
-  StorageService {
+class StorageServiceImpl @Inject constructor(
+  private val firestore: FirebaseFirestore,
+  private val auth: AccountService
+  ) : StorageService {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   override val tasks: Flow<List<Task>>
@@ -57,6 +57,26 @@ constructor(private val firestore: FirebaseFirestore, private val auth: AccountS
 
   override suspend fun delete(taskId: String) {
     firestore.collection(TASK_COLLECTION).document(taskId).delete().await()
+  }
+
+  override suspend fun getCompletedTasksCount(): Int {
+    return 456
+  }
+
+  override suspend fun getImportantCompletedTasksCount(): Int {
+    return 123
+  }
+
+  override suspend fun getAverageCompletionTime(): Int {
+    return 890
+  }
+
+  override suspend fun getMediumHighTasksToCompleteCount(): Int {
+    return 678
+  }
+
+  override suspend fun getOverdueTasksCount(): Int {
+    return 12
   }
 
   companion object {

--- a/final/app/src/main/java/com/example/makeitso/screens/edit_task/EditTaskScreen.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/edit_task/EditTaskScreen.kt
@@ -89,8 +89,8 @@ fun EditTaskScreenContent(
     ActionToolbar(
       title = AppText.edit_task,
       modifier = Modifier.toolbarActions(),
-      endActionIcon = AppIcon.ic_check,
-      endAction = { onDoneClick() }
+      primaryActionIcon = AppIcon.ic_check,
+      primaryAction = { onDoneClick() }
     )
 
     Spacer(modifier = Modifier.spacer())

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -63,7 +64,6 @@ fun StatsScreenContent(
     StatsItem(titleRes = AppText.important_completed_tasks, value = uiState.importantCompletedTasks)
     StatsItem(titleRes = AppText.average_completion_time, value = uiState.averageCompletionTime)
     StatsItem(titleRes = AppText.medium_high_tasks_to_complete, value = uiState.mediumHighTasksToComplete)
-    StatsItem(titleRes = AppText.overdue_tasks, value = uiState.overdueTasks)
   }
 }
 
@@ -81,7 +81,12 @@ fun StatsItem(titleRes: Int, value: String) {
         modifier = Modifier.weight(1f),
         horizontalAlignment = Alignment.CenterHorizontally
       ) {
-        Text(text = stringResource(id = titleRes), style = MaterialTheme.typography.subtitle1)
+        Text(
+          text = stringResource(id = titleRes),
+          style = MaterialTheme.typography.subtitle1,
+          textAlign = TextAlign.Center
+        )
+
         Text(text = value, fontSize = 48.sp)
       }
     }

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
@@ -71,22 +71,23 @@ fun StatsScreenContent(
 fun StatsItem(titleRes: Int, value: String) {
   Card(
     backgroundColor = MaterialTheme.colors.background,
-    modifier = Modifier.padding(8.dp, 0.dp, 8.dp, 8.dp),
+    modifier = Modifier.padding(8.dp, 0.dp, 8.dp, 0.dp),
   ) {
     Row(
       verticalAlignment = Alignment.CenterVertically,
-      modifier = Modifier.fillMaxWidth(),
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 0.dp, vertical = 24.dp),
     ) {
       Column(
         modifier = Modifier.weight(1f),
         horizontalAlignment = Alignment.CenterHorizontally
       ) {
-        Spacer(modifier = Modifier.smallSpacer())
         Text(text = stringResource(id = titleRes), style = MaterialTheme.typography.subtitle1)
-        Text(text = value, fontSize = 72.sp)
+        Text(text = value, fontSize = 48.sp)
       }
     }
   }
+
+  Spacer(modifier = Modifier.smallSpacer())
 }
 
 @Preview(showBackground = true)

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
@@ -62,7 +62,6 @@ fun StatsScreenContent(
 
     StatsItem(titleRes = AppText.completed_tasks, value = uiState.completedTasksCount)
     StatsItem(titleRes = AppText.important_completed_tasks, value = uiState.importantCompletedTasksCount)
-    StatsItem(titleRes = AppText.average_completion_time, value = uiState.averageCompletionTime)
     StatsItem(titleRes = AppText.medium_high_tasks_to_complete, value = uiState.mediumHighTasksToCompleteCount)
   }
 }

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.example.makeitso.screens.stats
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.makeitso.R.string as AppText
+import com.example.makeitso.common.composable.*
+import com.example.makeitso.common.ext.smallSpacer
+import com.example.makeitso.theme.MakeItSoTheme
+
+@ExperimentalMaterialApi
+@Composable
+fun StatsScreen(
+  viewModel: StatsViewModel = hiltViewModel()
+) {
+  val uiState by viewModel.uiState
+
+  StatsScreenContent(uiState = uiState)
+}
+
+@Composable
+fun StatsScreenContent(
+  modifier: Modifier = Modifier,
+  uiState: StatsUiState
+) {
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .fillMaxHeight()
+      .verticalScroll(rememberScrollState()),
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    BasicToolbar(AppText.stats)
+
+    Spacer(modifier = Modifier.smallSpacer())
+
+    StatsItem(titleRes = AppText.completed_tasks, value = uiState.completedTasks)
+    StatsItem(titleRes = AppText.important_completed_tasks, value = uiState.importantCompletedTasks)
+    StatsItem(titleRes = AppText.average_completion_time, value = uiState.averageCompletionTime)
+    StatsItem(titleRes = AppText.medium_high_tasks_to_complete, value = uiState.mediumHighTasksToComplete)
+    StatsItem(titleRes = AppText.overdue_tasks, value = uiState.overdueTasks)
+  }
+}
+
+@Composable
+fun StatsItem(titleRes: Int, value: String) {
+  Card(
+    backgroundColor = MaterialTheme.colors.background,
+    modifier = Modifier.padding(8.dp, 0.dp, 8.dp, 8.dp),
+  ) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      Column(
+        modifier = Modifier.weight(1f),
+        horizontalAlignment = Alignment.CenterHorizontally
+      ) {
+        Spacer(modifier = Modifier.smallSpacer())
+        Text(text = stringResource(id = titleRes), style = MaterialTheme.typography.subtitle1)
+        Text(text = value, fontSize = 72.sp)
+      }
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun StatsScreenPreview() {
+  MakeItSoTheme {
+    StatsScreenContent(
+      uiState = StatsUiState()
+    )
+  }
+}

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
@@ -60,15 +60,15 @@ fun StatsScreenContent(
 
     Spacer(modifier = Modifier.smallSpacer())
 
-    StatsItem(titleRes = AppText.completed_tasks, value = uiState.completedTasks)
-    StatsItem(titleRes = AppText.important_completed_tasks, value = uiState.importantCompletedTasks)
+    StatsItem(titleRes = AppText.completed_tasks, value = uiState.completedTasksCount)
+    StatsItem(titleRes = AppText.important_completed_tasks, value = uiState.importantCompletedTasksCount)
     StatsItem(titleRes = AppText.average_completion_time, value = uiState.averageCompletionTime)
-    StatsItem(titleRes = AppText.medium_high_tasks_to_complete, value = uiState.mediumHighTasksToComplete)
+    StatsItem(titleRes = AppText.medium_high_tasks_to_complete, value = uiState.mediumHighTasksToCompleteCount)
   }
 }
 
 @Composable
-fun StatsItem(titleRes: Int, value: String) {
+fun StatsItem(titleRes: Int, value: Long) {
   Card(
     backgroundColor = MaterialTheme.colors.background,
     modifier = Modifier.padding(8.dp, 0.dp, 8.dp, 0.dp),
@@ -87,7 +87,7 @@ fun StatsItem(titleRes: Int, value: String) {
           textAlign = TextAlign.Center
         )
 
-        Text(text = value, fontSize = 48.sp)
+        Text(text = "$value", fontSize = 48.sp)
       }
     }
   }

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsScreen.kt
@@ -67,7 +67,7 @@ fun StatsScreenContent(
 }
 
 @Composable
-fun StatsItem(titleRes: Int, value: Long) {
+fun StatsItem(titleRes: Int, value: Int) {
   Card(
     backgroundColor = MaterialTheme.colors.background,
     modifier = Modifier.padding(8.dp, 0.dp, 8.dp, 0.dp),

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
@@ -19,6 +19,5 @@ package com.example.makeitso.screens.stats
 data class StatsUiState(
     val completedTasksCount: Long = 0,
     val importantCompletedTasksCount: Long = 0,
-    val averageCompletionTime: Long = 0,
     val mediumHighTasksToCompleteCount: Long = 0
 )

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
@@ -17,7 +17,7 @@ limitations under the License.
 package com.example.makeitso.screens.stats
 
 data class StatsUiState(
-    val completedTasksCount: Long = 0,
-    val importantCompletedTasksCount: Long = 0,
-    val mediumHighTasksToCompleteCount: Long = 0
+    val completedTasksCount: Int = 0,
+    val importantCompletedTasksCount: Int = 0,
+    val mediumHighTasksToCompleteCount: Int = 0
 )

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
@@ -17,8 +17,8 @@ limitations under the License.
 package com.example.makeitso.screens.stats
 
 data class StatsUiState(
-    val completedTasks: String = "0",
-    val importantCompletedTasks: String = "0",
-    val averageCompletionTime: String = "0",
-    val mediumHighTasksToComplete: String = "0"
+    val completedTasksCount: Long = 0,
+    val importantCompletedTasksCount: Long = 0,
+    val averageCompletionTime: Long = 0,
+    val mediumHighTasksToCompleteCount: Long = 0
 )

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Google LLC
+Copyright 2023 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-package com.example.makeitso
+package com.example.makeitso.screens.stats
 
-const val SPLASH_SCREEN = "SplashScreen"
-const val SETTINGS_SCREEN = "SettingsScreen"
-const val LOGIN_SCREEN = "LoginScreen"
-const val SIGN_UP_SCREEN = "SignUpScreen"
-const val TASKS_SCREEN = "TasksScreen"
-const val EDIT_TASK_SCREEN = "EditTaskScreen"
-const val STATS_SCREEN = "StatsScreen"
-
-const val TASK_ID = "taskId"
-const val TASK_ID_ARG = "?$TASK_ID={$TASK_ID}"
+data class StatsUiState(
+    val completedTasks: String = "0",
+    val importantCompletedTasks: String = "0",
+    val averageCompletionTime: String = "0",
+    val mediumHighTasksToComplete: String = "0",
+    val overdueTasks: String = "0"
+)

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsUiState.kt
@@ -20,6 +20,5 @@ data class StatsUiState(
     val completedTasks: String = "0",
     val importantCompletedTasks: String = "0",
     val averageCompletionTime: String = "0",
-    val mediumHighTasksToComplete: String = "0",
-    val overdueTasks: String = "0"
+    val mediumHighTasksToComplete: String = "0"
 )

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
@@ -38,7 +38,6 @@ class StatsViewModel @Inject constructor(
     val updatedUiState = StatsUiState(
       completedTasksCount = storageService.getCompletedTasksCount(),
       importantCompletedTasksCount = storageService.getImportantCompletedTasksCount(),
-      averageCompletionTime = storageService.getAverageCompletionTime(),
       mediumHighTasksToCompleteCount = storageService.getMediumHighTasksToCompleteCount()
     )
 

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
@@ -37,10 +37,9 @@ class StatsViewModel @Inject constructor(
   private suspend fun loadStats() {
     val updatedUiState = StatsUiState(
       completedTasks = storageService.getCompletedTasksCount().toString(),
-      importantCompletedTasks = storageService.getImportantCompletedTasksCount().toString(),
-      averageCompletionTime = storageService.getAverageCompletionTime().toString(),
-      mediumHighTasksToComplete = storageService.getMediumHighTasksToCompleteCount().toString(),
-      overdueTasks = storageService.getOverdueTasksCount().toString()
+     // importantCompletedTasks = storageService.getImportantCompletedTasksCount().toString(),
+     // averageCompletionTime = storageService.getAverageCompletionTime().toString(),
+     // mediumHighTasksToComplete = storageService.getMediumHighTasksToCompleteCount().toString(),
     )
 
     uiState.value = updatedUiState

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.example.makeitso.screens.stats
+
+import androidx.compose.runtime.mutableStateOf
+import com.example.makeitso.model.service.LogService
+import com.example.makeitso.model.service.StorageService
+import com.example.makeitso.screens.MakeItSoViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class StatsViewModel @Inject constructor(
+  logService: LogService,
+  private val storageService: StorageService
+) : MakeItSoViewModel(logService) {
+  val uiState = mutableStateOf(StatsUiState())
+}

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
@@ -37,9 +37,9 @@ class StatsViewModel @Inject constructor(
   private suspend fun loadStats() {
     val updatedUiState = StatsUiState(
       completedTasks = storageService.getCompletedTasksCount().toString(),
-     // importantCompletedTasks = storageService.getImportantCompletedTasksCount().toString(),
-     // averageCompletionTime = storageService.getAverageCompletionTime().toString(),
-     // mediumHighTasksToComplete = storageService.getMediumHighTasksToCompleteCount().toString(),
+      importantCompletedTasks = storageService.getImportantCompletedTasksCount().toString(),
+      averageCompletionTime = storageService.getAverageCompletionTime().toString(),
+      mediumHighTasksToComplete = storageService.getMediumHighTasksToCompleteCount().toString()
     )
 
     uiState.value = updatedUiState

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
@@ -36,10 +36,10 @@ class StatsViewModel @Inject constructor(
 
   private suspend fun loadStats() {
     val updatedUiState = StatsUiState(
-      completedTasks = storageService.getCompletedTasksCount().toString(),
-      importantCompletedTasks = storageService.getImportantCompletedTasksCount().toString(),
-      averageCompletionTime = storageService.getAverageCompletionTime().toString(),
-      mediumHighTasksToComplete = storageService.getMediumHighTasksToCompleteCount().toString()
+      completedTasksCount = storageService.getCompletedTasksCount(),
+      importantCompletedTasksCount = storageService.getImportantCompletedTasksCount(),
+      averageCompletionTime = storageService.getAverageCompletionTime(),
+      mediumHighTasksToCompleteCount = storageService.getMediumHighTasksToCompleteCount()
     )
 
     uiState.value = updatedUiState

--- a/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/stats/StatsViewModel.kt
@@ -29,4 +29,20 @@ class StatsViewModel @Inject constructor(
   private val storageService: StorageService
 ) : MakeItSoViewModel(logService) {
   val uiState = mutableStateOf(StatsUiState())
+
+  init {
+    launchCatching { loadStats() }
+  }
+
+  private suspend fun loadStats() {
+    val updatedUiState = StatsUiState(
+      completedTasks = storageService.getCompletedTasksCount().toString(),
+      importantCompletedTasks = storageService.getImportantCompletedTasksCount().toString(),
+      averageCompletionTime = storageService.getAverageCompletionTime().toString(),
+      mediumHighTasksToComplete = storageService.getMediumHighTasksToCompleteCount().toString(),
+      overdueTasks = storageService.getOverdueTasksCount().toString()
+    )
+
+    uiState.value = updatedUiState
+  }
 }

--- a/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksScreen.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksScreen.kt
@@ -50,6 +50,7 @@ fun TasksScreen(
     tasks = tasks.value,
     options = options,
     onAddClick = viewModel::onAddClick,
+    onStatsClick = viewModel::onStatsClick,
     onSettingsClick = viewModel::onSettingsClick,
     onTaskCheckChange = viewModel::onTaskCheckChange,
     onTaskActionClick = viewModel::onTaskActionClick,
@@ -67,6 +68,7 @@ fun TasksScreenContent(
   tasks: List<Task>,
   options: List<String>,
   onAddClick: ((String) -> Unit) -> Unit,
+  onStatsClick: ((String) -> Unit) -> Unit,
   onSettingsClick: ((String) -> Unit) -> Unit,
   onTaskCheckChange: (Task) -> Unit,
   onTaskActionClick: ((String) -> Unit, Task, String) -> Unit,
@@ -90,8 +92,10 @@ fun TasksScreenContent(
       ActionToolbar(
         title = AppText.tasks,
         modifier = Modifier.toolbarActions(),
-        endActionIcon = AppIcon.ic_settings,
-        endAction = { onSettingsClick(openScreen) }
+        primaryActionIcon = AppIcon.ic_stats,
+        primaryAction = { onStatsClick(openScreen) },
+        secondaryActionIcon = AppIcon.ic_settings,
+        secondaryAction = { onSettingsClick(openScreen) }
       )
 
       Spacer(modifier = Modifier.smallSpacer())
@@ -127,6 +131,7 @@ fun TasksScreenPreview() {
       tasks = listOf(task),
       options = options,
       onAddClick = { },
+      onStatsClick = { },
       onSettingsClick = { },
       onTaskCheckChange = { },
       onTaskActionClick = { _, _, _ -> },

--- a/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
@@ -48,20 +48,19 @@ class TasksViewModel @Inject constructor(
 
   fun onTaskCheckChange(task: Task) {
     launchCatching {
-      if (task.completed) {
-        storageService.update(task.copy(completed = false, completionTime = null))
-      } else {
-        val completionTime = getCompletionTime(task)
-        storageService.update(task.copy(completed = true, completionTime = completionTime))
-      }
+      val updatedTask = task.copy(completed = !task.completed)
+      val completionTime = getCompletionTime(updatedTask)
+      storageService.update(updatedTask.copy(completionTime = completionTime))
     }
   }
 
-  private fun getCompletionTime(task: Task): Long {
-    val now = Timestamp.now().toDate().toInstant()
-    val creationInstant = task.creationInstant.toInstant()
-    val completionTime = Duration.between(creationInstant, now)
-    return completionTime.toHours()
+  private fun getCompletionTime(task: Task): Long? {
+    return if (task.completed) {
+      val now = Timestamp.now().toDate().toInstant()
+      val creationInstant = task.creationInstant.toInstant()
+      val completionTime = Duration.between(creationInstant, now)
+      return completionTime.toHours()
+    } else null
   }
 
   fun onAddClick(openScreen: (String) -> Unit) = openScreen(EDIT_TASK_SCREEN)

--- a/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
@@ -50,14 +50,14 @@ class TasksViewModel @Inject constructor(
     launchCatching {
       val updatedTask = task.copy(completed = !task.completed)
       val completionTime = getCompletionTime(updatedTask)
-      storageService.update(updatedTask.copy(completionTime = completionTime))
+      storageService.update(updatedTask.copy(averageCompletionTime = completionTime))
     }
   }
 
   private fun getCompletionTime(task: Task): Long? {
     return if (task.completed) {
       val now = Timestamp.now().toDate().toInstant()
-      val creationInstant = task.creationInstant.toInstant()
+      val creationInstant = task.createdAt.toInstant()
       val completionTime = Duration.between(creationInstant, now)
       return completionTime.toHours()
     } else null

--- a/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
@@ -26,11 +26,10 @@ import com.example.makeitso.model.service.ConfigurationService
 import com.example.makeitso.model.service.LogService
 import com.example.makeitso.model.service.StorageService
 import com.example.makeitso.screens.MakeItSoViewModel
+import com.google.firebase.Timestamp
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.Duration
-import java.time.Instant
 import javax.inject.Inject
-import kotlin.time.toKotlinDuration
 
 @HiltViewModel
 class TasksViewModel @Inject constructor(
@@ -52,12 +51,17 @@ class TasksViewModel @Inject constructor(
       if (task.completed) {
         storageService.update(task.copy(completed = false, completionTime = null))
       } else {
-        val creationInstant = Instant.parse(task.creationInstant)
-        val durationBetween = Duration.between(creationInstant, Instant.now())
-        val completionTime = durationBetween.toKotlinDuration().inWholeHours
+        val completionTime = getCompletionTime(task)
         storageService.update(task.copy(completed = true, completionTime = completionTime))
       }
     }
+  }
+
+  private fun getCompletionTime(task: Task): Long {
+    val now = Timestamp.now().toDate().toInstant()
+    val creationInstant = task.creationInstant.toInstant()
+    val completionTime = Duration.between(creationInstant, now)
+    return completionTime.toHours()
   }
 
   fun onAddClick(openScreen: (String) -> Unit) = openScreen(EDIT_TASK_SCREEN)

--- a/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
@@ -26,9 +26,7 @@ import com.example.makeitso.model.service.ConfigurationService
 import com.example.makeitso.model.service.LogService
 import com.example.makeitso.model.service.StorageService
 import com.example.makeitso.screens.MakeItSoViewModel
-import com.google.firebase.Timestamp
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.time.Duration
 import javax.inject.Inject
 
 @HiltViewModel
@@ -47,20 +45,7 @@ class TasksViewModel @Inject constructor(
   }
 
   fun onTaskCheckChange(task: Task) {
-    launchCatching {
-      val updatedTask = task.copy(completed = !task.completed)
-      val completionTime = getCompletionTime(updatedTask)
-      storageService.update(updatedTask.copy(averageCompletionTime = completionTime))
-    }
-  }
-
-  private fun getCompletionTime(task: Task): Long? {
-    return if (task.completed) {
-      val now = Timestamp.now().toDate().toInstant()
-      val creationInstant = task.createdAt.toInstant()
-      val completionTime = Duration.between(creationInstant, now)
-      return completionTime.toHours()
-    } else null
+    launchCatching { storageService.update(task.copy(completed = !task.completed)) }
   }
 
   fun onAddClick(openScreen: (String) -> Unit) = openScreen(EDIT_TASK_SCREEN)

--- a/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
@@ -19,6 +19,7 @@ package com.example.makeitso.screens.tasks
 import androidx.compose.runtime.mutableStateOf
 import com.example.makeitso.EDIT_TASK_SCREEN
 import com.example.makeitso.SETTINGS_SCREEN
+import com.example.makeitso.STATS_SCREEN
 import com.example.makeitso.TASK_ID
 import com.example.makeitso.model.Task
 import com.example.makeitso.model.service.ConfigurationService
@@ -50,6 +51,8 @@ class TasksViewModel @Inject constructor(
   fun onAddClick(openScreen: (String) -> Unit) = openScreen(EDIT_TASK_SCREEN)
 
   fun onSettingsClick(openScreen: (String) -> Unit) = openScreen(SETTINGS_SCREEN)
+
+  fun onStatsClick(openScreen: (String) -> Unit) = openScreen(STATS_SCREEN)
 
   fun onTaskActionClick(openScreen: (String) -> Unit, task: Task, action: String) {
     when (TaskActionOption.getByTitle(action)) {

--- a/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
@@ -27,6 +27,7 @@ import com.example.makeitso.model.service.LogService
 import com.example.makeitso.model.service.StorageService
 import com.example.makeitso.screens.MakeItSoViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -45,7 +46,15 @@ class TasksViewModel @Inject constructor(
   }
 
   fun onTaskCheckChange(task: Task) {
-    launchCatching { storageService.update(task.copy(completed = !task.completed)) }
+    launchCatching {
+      if (task.completed) {
+        storageService.update(task.copy(completed = false, completionTime = null))
+      } else {
+        val creationInstant = Instant.parse(task.creationInstant)
+        val completionTime = Instant.now().compareTo(creationInstant)
+        storageService.update(task.copy(completed = true, completionTime = completionTime))
+      }
+    }
   }
 
   fun onAddClick(openScreen: (String) -> Unit) = openScreen(EDIT_TASK_SCREEN)

--- a/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
+++ b/final/app/src/main/java/com/example/makeitso/screens/tasks/TasksViewModel.kt
@@ -27,8 +27,10 @@ import com.example.makeitso.model.service.LogService
 import com.example.makeitso.model.service.StorageService
 import com.example.makeitso.screens.MakeItSoViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
+import kotlin.time.toKotlinDuration
 
 @HiltViewModel
 class TasksViewModel @Inject constructor(
@@ -51,7 +53,8 @@ class TasksViewModel @Inject constructor(
         storageService.update(task.copy(completed = false, completionTime = null))
       } else {
         val creationInstant = Instant.parse(task.creationInstant)
-        val completionTime = Instant.now().compareTo(creationInstant)
+        val durationBetween = Duration.between(creationInstant, Instant.now())
+        val completionTime = durationBetween.toKotlinDuration().inWholeHours
         storageService.update(task.copy(completed = true, completionTime = completionTime))
       }
     }

--- a/final/app/src/main/res/drawable/ic_stats.xml
+++ b/final/app/src/main/res/drawable/ic_stats.xml
@@ -1,0 +1,7 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M4,9h4v11h-4z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M16,13h4v7h-4z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M10,4h4v16h-4z"/>
+</vector>

--- a/final/app/src/main/res/values/strings.xml
+++ b/final/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="stats">Statistics</string>
     <string name="completed_tasks">Completed tasks</string>
     <string name="important_completed_tasks">Important completed tasks \n (high priority or flagged)</string>
-    <string name="average_completion_time">Average time to complete a task</string>
+    <string name="average_completion_time">Average time to complete a task \n (in hours)</string>
     <string name="medium_high_tasks_to_complete">Medium and high priority tasks to complete</string>
     <string name="overdue_tasks">Overdue tasks</string>
 

--- a/final/app/src/main/res/values/strings.xml
+++ b/final/app/src/main/res/values/strings.xml
@@ -46,7 +46,6 @@
     <string name="important_completed_tasks">Important completed tasks \n (high priority or flagged)</string>
     <string name="average_completion_time">Average time to complete a task \n (in hours)</string>
     <string name="medium_high_tasks_to_complete">Medium and high priority tasks to complete</string>
-    <string name="overdue_tasks">Overdue tasks</string>
 
     <!-- Dialogs -->
     <string name="sign_out_title">Sign out?</string>

--- a/final/app/src/main/res/values/strings.xml
+++ b/final/app/src/main/res/values/strings.xml
@@ -40,6 +40,14 @@
     <string name="sign_out">Sign out</string>
     <string name="delete_my_account">Delete my account</string>
 
+    <!-- StatsScreen -->
+    <string name="stats">Statistics</string>
+    <string name="completed_tasks">Completed tasks</string>
+    <string name="important_completed_tasks">Important completed tasks \n (high priority or flagged)</string>
+    <string name="average_completion_time">Average time to complete a task</string>
+    <string name="medium_high_tasks_to_complete">Medium and high priority tasks to complete</string>
+    <string name="overdue_tasks">Overdue tasks</string>
+
     <!-- Dialogs -->
     <string name="sign_out_title">Sign out?</string>
     <string name="sign_out_description">You will have to sign in again to see your tasks.</string>

--- a/final/app/src/main/res/values/strings.xml
+++ b/final/app/src/main/res/values/strings.xml
@@ -44,7 +44,6 @@
     <string name="stats">Statistics</string>
     <string name="completed_tasks">Completed tasks</string>
     <string name="important_completed_tasks">Important completed tasks \n (high priority or flagged)</string>
-    <string name="average_completion_time">Average time to complete a task \n (in hours)</string>
     <string name="medium_high_tasks_to_complete">Medium and high priority tasks to complete</string>
 
     <!-- Dialogs -->


### PR DESCRIPTION
Add _Statistic screen_, accessible from the main screen (_Tasks screen_). This screen shows the number of completed tasks, important completed tasks and how many Medium to High priority tasks are yet to be completed. `StatsViewModel` pulls all data from `StorageService`, which is the file where we perform all calls to Firestore. The new calls involve more complex queries, using a mix of `OR`, `AND`, `IN` and `WHERE`.

![updated-stats](https://github.com/FirebaseExtended/make-it-so-android/assets/14080129/cb0e0cf0-df8a-470a-814e-c97c9ed2378e)
